### PR TITLE
feat: Add Datamaintain

### DIFF
--- a/srv/db/v10__insert_4sh_dashboards.js
+++ b/srv/db/v10__insert_4sh_dashboards.js
@@ -1,75 +1,64 @@
-var script = db.getCollection('scripts').findOne({_id: 'v10__insert_4sh_dashboards.js'});
-
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-    db.getCollection('dashboardConfigurations').insert([
-        {
-            "companyRef" : "53c535a5c8d11a14c7269436",
-            "title": "Dashboard administratif",
-            "role" : "ADMINISTRATIVE",
-            "columnConfigurations" : [
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.to.prepare",
-                    "invoiceStatus" : "READY"
-                },
-                {
-                    "actionRequired" : true,
-                    "disabled" : false,
-                    "title" : "dashboard.column.validation.waiting",
-                    "invoiceStatus" : "WAITING_VALIDATION"
-                },
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.to.send",
-                    "invoiceStatus" : "VALIDATED"
-                },
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.payment.waiting",
-                    "invoiceStatus" : "SENT"
-                },
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.late",
-                    "invoiceStatus" : "LATE"
-                }
-            ]
-        },
-        {
-            "companyRef" : "53c535a5c8d11a14c7269436",
-            "title": "Dashboard pilotes projet",
-            "role" : "INVOICING",
-            "columnConfigurations" : [
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.draft",
-                    "invoiceStatus" : "DRAFT"
-                },
-                {
-                    "actionRequired" : false,
-                    "disabled" : true,
-                    "title" : "dashboard.column.preparation.waiting",
-                    "invoiceStatus" : "READY"
-                },
-                {
-                    "actionRequired" : false,
-                    "disabled" : false,
-                    "title" : "dashboard.column.to.validate",
-                    "invoiceStatus" : "WAITING_VALIDATION"
-                }
-            ]
-        }
-    ]);
-    db.getCollection('scripts').save(
-        {
-            _id: "v10__insert_4sh_dashboards.js",
-            "atDate": ISODate()
-        });
-}
+db.getCollection('dashboardConfigurations').insert([
+    {
+        "companyRef": "53c535a5c8d11a14c7269436",
+        "title": "Dashboard administratif",
+        "role": "ADMINISTRATIVE",
+        "columnConfigurations": [
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.to.prepare",
+                "invoiceStatus": "READY"
+            },
+            {
+                "actionRequired": true,
+                "disabled": false,
+                "title": "dashboard.column.validation.waiting",
+                "invoiceStatus": "WAITING_VALIDATION"
+            },
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.to.send",
+                "invoiceStatus": "VALIDATED"
+            },
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.payment.waiting",
+                "invoiceStatus": "SENT"
+            },
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.late",
+                "invoiceStatus": "LATE"
+            }
+        ]
+    },
+    {
+        "companyRef": "53c535a5c8d11a14c7269436",
+        "title": "Dashboard pilotes projet",
+        "role": "INVOICING",
+        "columnConfigurations": [
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.draft",
+                "invoiceStatus": "DRAFT"
+            },
+            {
+                "actionRequired": false,
+                "disabled": true,
+                "title": "dashboard.column.preparation.waiting",
+                "invoiceStatus": "READY"
+            },
+            {
+                "actionRequired": false,
+                "disabled": false,
+                "title": "dashboard.column.to.validate",
+                "invoiceStatus": "WAITING_VALIDATION"
+            }
+        ]
+    }
+]);

--- a/srv/db/v1__users_management.js
+++ b/srv/db/v1__users_management.js
@@ -1,55 +1,45 @@
-var script = db.getCollection('scripts').findOne({_id: 'v1__users_management.js'});
+var user4pm = db.getCollection('users').findOne(ObjectId("53c53624c8d11a14c7269438"));
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
+delete user4pm.password;
+delete user4pm.login;
 
-    var user4pm = db.getCollection('users').findOne(ObjectId("53c53624c8d11a14c7269438"));
+db.getCollection('users').save(user4pm);
 
-    delete user4pm.password;
-    delete user4pm.login;
-
-    db.getCollection('users').save(user4pm);
-
-    db.getCollection('userCredentials').save({
-        "_id": user4pm._id,
-        "passwordHash": "$2a$10$inWo7nwU86em5BqdMpcYSO4LxRheTgm2E479hmlQ/hmWEqckSOof."
-    });
-    // Password hash computed with bcrypt(098f6bcd4621d373cade4e832627b4f6)
+db.getCollection('userCredentials').save({
+    "_id": user4pm._id,
+    "passwordHash": "$2a$10$inWo7nwU86em5BqdMpcYSO4LxRheTgm2E479hmlQ/hmWEqckSOof."
+});
+// Password hash computed with bcrypt(098f6bcd4621d373cade4e832627b4f6)
 
 
-    var user4sh = db.getCollection('users').findOne(ObjectId("53c66756c8d11a14c7269439"));
+var user4sh = db.getCollection('users').findOne(ObjectId("53c66756c8d11a14c7269439"));
 
-    delete user4sh.password;
-    delete user4sh.login;
+delete user4sh.password;
+delete user4sh.login;
 
-    user4sh.name = '4sh';
+user4sh.name = '4sh';
 
-    db.getCollection('users').save(user4sh);
+db.getCollection('users').save(user4sh);
 
-    db.getCollection('userCredentials').save({
-        "_id": user4sh._id,
-        "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
-    });
-    // Password hash computed with md5+bcrypt(<realPassword>)
-
-
-    var userPrint = db.getCollection('users').findOne(ObjectId("54f6fed80940029aa34ec005"));
-
-    delete userPrint.password;
-    delete userPrint.login;
-
-    userPrint.name = 'print';
-    userPrint.email = null;
-
-    db.getCollection('users').save(userPrint);
-
-    db.getCollection('userCredentials').save({
-        "_id": userPrint._id,
-        "passwordHash": "$2a$10$SfQLEM/o72rqRgzYZk8mgu9sev1T7jagrWNBfU5HORtD9sRxWtjI."
-    });
-    // Password hash computed with bcrypt(a93d7f10a1f30aedcc1fa7ea4513e80d)
+db.getCollection('userCredentials').save({
+    "_id": user4sh._id,
+    "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
+});
+// Password hash computed with md5+bcrypt(<realPassword>)
 
 
-    db.getCollection('scripts').save({_id: 'v1__users_management.js', atDate: new ISODate()});
-}
+var userPrint = db.getCollection('users').findOne(ObjectId("54f6fed80940029aa34ec005"));
+
+delete userPrint.password;
+delete userPrint.login;
+
+userPrint.name = 'print';
+userPrint.email = null;
+
+db.getCollection('users').save(userPrint);
+
+db.getCollection('userCredentials').save({
+    "_id": userPrint._id,
+    "passwordHash": "$2a$10$SfQLEM/o72rqRgzYZk8mgu9sev1T7jagrWNBfU5HORtD9sRxWtjI."
+});
+// Password hash computed with bcrypt(a93d7f10a1f30aedcc1fa7ea4513e80d)

--- a/srv/db/v2__add_users.js
+++ b/srv/db/v2__add_users.js
@@ -1,36 +1,23 @@
-var script = db.getCollection('scripts').findOne({_id: 'v2__add_users.js'});
+var user_AGA = {
+    name: "AGA",
+    email: "amandine.guerra@4sh.fr",
+    roles: ["seller"],
+};
+var user_CRT = {
+    name: "CRT",
+    email: "camille.renault@4sh.fr",
+    roles: ["seller"]
+};
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-
-    var user_AGA = {
-        name: "AGA",
-        email: "amandine.guerra@4sh.fr",
-        roles: ["seller"],
-    };
-    var user_CRT = {
-        name: "CRT",
-        email: "camille.renault@4sh.fr",
-        roles: ["seller"]
-    };
-
-    db.getCollection('users').save(user_AGA);
-    user_AGA._id = db.getCollection('users').findOne({email: user_AGA.email})._id;
-    db.getCollection('userCredentials').save({
-        "_id": user_AGA._id,
-        "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
-    });
-    db.getCollection('users').save(user_CRT);
-    user_CRT._id = db.getCollection('users').findOne({email: user_CRT.email})._id;
-    db.getCollection('userCredentials').save({
-        "_id": user_CRT._id,
-        "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
-    });
-
-    db.getCollection('scripts').save(
-        {
-            _id: "v2__add_users.js",
-            "atDate": ISODate()
-        });
-}
+db.getCollection('users').save(user_AGA);
+user_AGA._id = db.getCollection('users').findOne({email: user_AGA.email})._id;
+db.getCollection('userCredentials').save({
+    "_id": user_AGA._id,
+    "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
+});
+db.getCollection('users').save(user_CRT);
+user_CRT._id = db.getCollection('users').findOne({email: user_CRT.email})._id;
+db.getCollection('userCredentials').save({
+    "_id": user_CRT._id,
+    "passwordHash": "$2a$10$8EiasZHADtkNkF2C2yhfx./qY75KRa1iE.hABZxqQYQ4lbjUxUjxa"
+});

--- a/srv/db/v3__migration_business.js
+++ b/srv/db/v3__migration_business.js
@@ -1,66 +1,54 @@
-var script = db.getCollection('scripts').findOne({_id: 'v3__migration_business.js'});
+var shSeller = db.getCollection('companies').findOne({name: "4SH"});
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
+var companyMetrics = db.getCollection('sellerCompanyMetrics').findOne({"sellerRef": shSeller._id + ""});
 
-    var shSeller = db.getCollection('companies').findOne({name: "4SH"});
+db.getCollection('companies').find().forEach(function (company) {
 
-    var companyMetrics = db.getCollection('sellerCompanyMetrics').findOne({"sellerRef": shSeller._id + ""});
+    var commercialRelationship = {
+        sellerRef: shSeller._id + "",
+        customerRef: company._id + "",
 
-    db.getCollection('companies').find().forEach(function (company) {
+        detail: company.detail,
+        legalNotice: company.legalNotice,
+        showLegalNoticeForeignBuyer: company.showLegalNoticeForeignBuyer,
 
-        var commercialRelationship = {
-            sellerRef: shSeller._id + "",
-            customerRef: company._id+ "",
+        lastSendDate: company.lastSendDate,
+        lastPaymentDate: company.lastPaymentDate,
+        lastSentInvoice: company.lastSentInvoice,
+        lastPaidInvoice: company.lastPaidInvoice,
+        companyMetrics: {
+            global: company.metrics,
+            previousYear: companyMetrics.buyerCompaniesMetrics[company._id + ""].previousYear,
+            currentYear: companyMetrics.buyerCompaniesMetrics[company._id + ""].currentYear,
+            nextYear: companyMetrics.buyerCompaniesMetrics[company._id + ""].nextYear
+        },
+        businessList: company.business,
+        vatRates: []
+    };
 
-            detail: company.detail,
-            legalNotice: company.legalNotice,
-            showLegalNoticeForeignBuyer: company.showLegalNoticeForeignBuyer,
-
-            lastSendDate: company.lastSendDate,
-            lastPaymentDate: company.lastPaymentDate,
-            lastSentInvoice: company.lastSentInvoice,
-            lastPaidInvoice: company.lastPaidInvoice,
-            companyMetrics: {
-                global: company.metrics,
-                previousYear: companyMetrics.buyerCompaniesMetrics[company._id+""].previousYear,
-                currentYear: companyMetrics.buyerCompaniesMetrics[company._id+""].currentYear,
-                nextYear: companyMetrics.buyerCompaniesMetrics[company._id+""].nextYear
-            },
-            businessList: company.business,
-            vatRates:[]
-        };
-
-        company.vats.forEach(function(vat) {
-            commercialRelationship.vatRates.push(
-               {
-                   rate: vat.amount,
-                   label: vat.vat
-               }
-           );
-        });
-        db.getCollection('commercialRelationships').save(commercialRelationship);
+    company.vats.forEach(function (vat) {
+        commercialRelationship.vatRates.push(
+            {
+                rate: vat.amount,
+                label: vat.vat
+            }
+        );
     });
+    db.getCollection('commercialRelationships').save(commercialRelationship);
+});
 
-    db.getCollection('companies').update({}, {
-        $unset: {
-            business: "",
-            vats: "",
-            metrics: "",
-            lastSendDate: "",
-            lastPaymentDate: "",
-            lastSentInvoice: "",
-            lastPaidInvoice: "",
-            detail: "",
-            legalNotice: "",
-            showLegalNoticeForeignBuyer: ""
+db.getCollection('companies').update({}, {
+    $unset: {
+        business: "",
+        vats: "",
+        metrics: "",
+        lastSendDate: "",
+        lastPaymentDate: "",
+        lastSentInvoice: "",
+        lastPaidInvoice: "",
+        detail: "",
+        legalNotice: "",
+        showLegalNoticeForeignBuyer: ""
 
-        }
-    }, {multi: true});
-    db.getCollection('scripts').save(
-        {
-            _id: "v3__migration_business.js",
-            "atDate": ISODate()
-        });
-}
+    }
+}, {multi: true});

--- a/srv/db/v4__insert_4sh_accoutant_service_reference.js
+++ b/srv/db/v4__insert_4sh_accoutant_service_reference.js
@@ -1,115 +1,103 @@
-var script = db.getCollection('scripts').findOne({_id: 'v4__insert_4sh_accountant_service_reference.js'});
+var quatreSHComp = db.getCollection('companies').findOne({name: "4SH"});
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
+if (quatreSHComp) {
+    quatreSHComp.sellerSettings = {
+        serviceReferenceList: [
+            {
+                kind: "SERVICE",
+                accountNumber: "706100",
+                vatRate: {
+                    rate: 850,
+                    accountNumber: "445712"
+                }
+            },
+            {
+                kind: "SERVICE",
+                accountNumber: "706110",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
+                }
+            },
+            {
+                kind: "SERVICE",
+                accountNumber: "706950"
+            },
+            {
+                kind: "SERVICE",
+                accountNumber: "706951"
+            },
+            {
+                kind: "FEE",
+                accountNumber: "708950",
+                // NO TVA
+            },
+            {
+                kind: "FEE",
+                accountNumber: "708100",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
+                }
 
-    var quatreSHComp = db.getCollection('companies').findOne({name: "4SH"});
-
-    if (quatreSHComp) {
-        quatreSHComp.sellerSettings = {
-            serviceReferenceList: [
-                {
-                    kind: "SERVICE",
-                    accountNumber: "706100",
-                    vatRate: {
-                        rate: 850,
-                        accountNumber: "445712"
-                    }
+            },
+            {
+                kind: "FEE",
+                accountNumber: "708000",
+                vatRate: {
+                    rate: 850,
+                    accountNumber: "445712"
+                }
+            },
+            {
+                kind: "TRAINING",
+                accountNumber: "706111",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
+                }
+            },
+            {
+                kind: "TRAINING",
+                accountNumber: "706112",
+                vatRate: {
+                    rate: 850,
+                    accountNumber: "445712"
+                }
+            },
+            {
+                kind: "HOSTING",
+                accountNumber: "706114",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
                 },
-                {
-                    kind: "SERVICE",
-                    accountNumber: "706110",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    }
+            },
+            {
+                kind: "SUBCONTRACTING",
+                accountNumber: "706113",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
                 },
-                {
-                    kind: "SERVICE",
-                    accountNumber: "706950"
+            },
+            {
+                kind: "BUY_SELL",
+                accountNumber: "707000",
+                vatRate: {
+                    rate: 2000,
+                    accountNumber: "445711"
                 },
-                {
-                    kind: "SERVICE",
-                    accountNumber: "706951"
+            },
+            {
+                kind: "BUY_SELL",
+                accountNumber: "707100",
+                vatRate: {
+                    rate: 850,
+                    accountNumber: "445712"
                 },
-                {
-                    kind: "FEE",
-                    accountNumber: "708950",
-                    // NO TVA
-                },
-                {
-                    kind: "FEE",
-                    accountNumber: "708100",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    }
-
-                },
-                {
-                    kind: "FEE",
-                    accountNumber: "708000",
-                    vatRate: {
-                        rate: 850,
-                        accountNumber: "445712"
-                    }
-                },
-                {
-                    kind: "TRAINING",
-                    accountNumber: "706111",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    }
-                },
-                {
-                    kind: "TRAINING",
-                    accountNumber: "706112",
-                    vatRate: {
-                        rate: 850,
-                        accountNumber: "445712"
-                    }
-                },
-                {
-                    kind: "HOSTING",
-                    accountNumber: "706114",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    },
-                },
-                {
-                    kind: "SUBCONTRACTING",
-                    accountNumber: "706113",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    },
-                },
-                {
-                    kind: "BUY_SELL",
-                    accountNumber: "707000",
-                    vatRate: {
-                        rate: 2000,
-                        accountNumber: "445711"
-                    },
-                },
-                {
-                    kind: "BUY_SELL",
-                    accountNumber: "707100",
-                    vatRate: {
-                        rate: 850,
-                        accountNumber: "445712"
-                    },
-                },
-            ]
-        };
-        db.getCollection('companies').save(quatreSHComp);
-    }
-    db.getCollection('scripts').save(
-        {
-            _id: "v4__insert_4sh_accountant_service_reference.js",
-            "atDate": ISODate()
-        });
+            },
+        ]
+    };
+    db.getCollection('companies').save(quatreSHComp);
 }

--- a/srv/db/v5__add_business_accountant_reference.js
+++ b/srv/db/v5__add_business_accountant_reference.js
@@ -1,91 +1,77 @@
-var script = db.getCollection('scripts').findOne({_id: 'v5__add_business_accountant_reference.js'});
+var quatreSHComp = db.getCollection('companies').findOne({name: "4SH"});
+var accountantReferences =
+    {
+        "ACA Nexia": "CACA",
+        "ACPPAV": "CACPPA",
+        "AFD Technologies": "CAFD",
+        "AGEFOS PME": "CAGEFO",
+        "AlgoLinked": "CALGOLIN",
+        "ALOGIA": "CALOGIA",
+        "ARKHÉ INTERNATIONAL": "CARKHE",
+        "ARRG": "CARRG",
+        "ASTREE CONSULTANT": "CASTREE",
+        "BeCLM": "CBECLM",
+        "BP2R": "CBP2R",
+        "BRAMBLES": "CCHEPUSA",
+        "SCA BRUN": "CBRUN",
+        "BRUN & JCD": "CBRUNJCD",
+        "BVD Assurances": "CBVD",
+        "CARGO INFORMATION NETWORK FRANCE": "CCARGOINFO",
+        "CHEP USA": "CCHEPUSA",
+        "CHIESI SAS": "CCHIESI",
+        "COOLS Environnement et Développement": "CCOOLS",
+        "DAM'S": "CDAM",
+        "DIANA TRANS": "CDIANA",
+        "Ets Ducasse Buzet SA": "CDUCASSE",
+        "EASYstem": "CEASYS",
+        "FAFIEC": "CFAFIEC",
+        "FILHET ALLARD & Cie": "CFILHET",
+        "FRAMATOME": "CFRAMATOM",
+        "FRANCE CARGO HANDLING": "CFRANCE",
+        "FSM": "CFSM",
+        "Infoport": "CINFOPORT",
+        "KeenTurtle": "CKEEN",
+        "Logitrade France Siège": "CLOGITRADE",
+        "MobySolve.4U": "CMOBY",
+        "NAVITRANS": "CNAVITR",
+        "NAXOS": "CNAXOS",
+        "NIPPON EXPRESS": "CNIPPON",
+        "OFEDO": "COFEDO",
+        "OKINA": "COKINA",
+        "OPCALIA REUNION": "COPCALIA",
+        "ORANO PROJETS SAS": "CORANO",
+        "450 SAS": "CQUATR",
+        "SCA ROSELINE BRUN": "CROSELINE",
+        "SANTEXCEL": "CSANTEX",
+        "S.A.P.E.S.O.": "CSAPESO",
+        "Société SEI": "CSEI",
+        "SEMMARIS": "CSEMMARIS",
+        "SIGMA Informatique": "CSIGMA",
+        "SI-nerGIE": "CSINERGIE",
+        "IZIVIA": "CSODETREL",
+        "SUPERPLASTIC": "CSUPERPLASTIC",
+        "TEKCAR": "CTECKCAR",
+        "TechnichAtome": "CTECHNICH",
+        "TN INTERNATIONAL": "CTNINTER",
+        "UNIVERSITÉ PIERRE ET MARIE CURIE": "CUNIVERSITE",
+        "URBISMART": "CURBIS",
+        "Wilmar Sugar SA": "CWILMARSA",
+        "XENASSUR": "CXENASSUR",
+        "EUROPEAN SOURCING": "CEUROSOURCING",
+        "Simatix": "CSIMATIX",
+        "La Charente Libre": "CCHARLIBRE",
+        "IN'COM": "CINCOM",
+        "Pyrénnées Presse": "CPYRPRESSE"
+    };
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-
-    var quatreSHComp = db.getCollection('companies').findOne({name: "4SH"});
-    var accountantReferences =
-        {
-            "ACA Nexia": "CACA",
-            "ACPPAV": "CACPPA",
-            "AFD Technologies": "CAFD",
-            "AGEFOS PME": "CAGEFO",
-            "AlgoLinked": "CALGOLIN",
-            "ALOGIA": "CALOGIA",
-            "ARKHÉ INTERNATIONAL": "CARKHE",
-            "ARRG": "CARRG",
-            "ASTREE CONSULTANT": "CASTREE",
-            "BeCLM": "CBECLM",
-            "BP2R": "CBP2R",
-            "BRAMBLES": "CCHEPUSA",
-            "SCA BRUN": "CBRUN",
-            "BRUN & JCD": "CBRUNJCD",
-            "BVD Assurances": "CBVD",
-            "CARGO INFORMATION NETWORK FRANCE": "CCARGOINFO",
-            "CHEP USA": "CCHEPUSA",
-            "CHIESI SAS": "CCHIESI",
-            "COOLS Environnement et Développement": "CCOOLS",
-            "DAM'S": "CDAM",
-            "DIANA TRANS": "CDIANA",
-            "Ets Ducasse Buzet SA": "CDUCASSE",
-            "EASYstem": "CEASYS",
-            "FAFIEC": "CFAFIEC",
-            "FILHET ALLARD & Cie": "CFILHET",
-            "FRAMATOME": "CFRAMATOM",
-            "FRANCE CARGO HANDLING": "CFRANCE",
-            "FSM": "CFSM",
-            "Infoport": "CINFOPORT",
-            "KeenTurtle": "CKEEN",
-            "Logitrade France Siège": "CLOGITRADE",
-            "MobySolve.4U": "CMOBY",
-            "NAVITRANS": "CNAVITR",
-            "NAXOS": "CNAXOS",
-            "NIPPON EXPRESS": "CNIPPON",
-            "OFEDO": "COFEDO",
-            "OKINA": "COKINA",
-            "OPCALIA REUNION": "COPCALIA",
-            "ORANO PROJETS SAS": "CORANO",
-            "450 SAS": "CQUATR",
-            "SCA ROSELINE BRUN": "CROSELINE",
-            "SANTEXCEL": "CSANTEX",
-            "S.A.P.E.S.O.": "CSAPESO",
-            "Société SEI": "CSEI",
-            "SEMMARIS": "CSEMMARIS",
-            "SIGMA Informatique": "CSIGMA",
-            "SI-nerGIE": "CSINERGIE",
-            "IZIVIA": "CSODETREL",
-            "SUPERPLASTIC": "CSUPERPLASTIC",
-            "TEKCAR": "CTECKCAR",
-            "TechnichAtome": "CTECHNICH",
-            "TN INTERNATIONAL": "CTNINTER",
-            "UNIVERSITÉ PIERRE ET MARIE CURIE": "CUNIVERSITE",
-            "URBISMART": "CURBIS",
-            "Wilmar Sugar SA": "CWILMARSA",
-            "XENASSUR": "CXENASSUR",
-            "EUROPEAN SOURCING": "CEUROSOURCING",
-            "Simatix": "CSIMATIX",
-            "La Charente Libre": "CCHARLIBRE",
-            "IN'COM": "CINCOM",
-            "Pyrénnées Presse": "CPYRPRESSE"
-        };
-
-    for (var key of Object.keys(accountantReferences)) {
-        var company = db.getCollection('companies').findOne({name: key});
-        if (!company) {
-            print(key)
-        } else {
-            db.getCollection('commercialRelationships').update({
-                customerRef: company._id + "",
-                sellerRef: quatreSHComp._id + ""
-            }, {$set: {accountantReference: accountantReferences[key]}});
-        }
+for (var key of Object.keys(accountantReferences)) {
+    var company = db.getCollection('companies').findOne({name: key});
+    if (!company) {
+        print(key)
+    } else {
+        db.getCollection('commercialRelationships').update({
+            customerRef: company._id + "",
+            sellerRef: quatreSHComp._id + ""
+        }, {$set: {accountantReference: accountantReferences[key]}});
     }
-
-
-    db.getCollection('scripts').save(
-        {
-            _id: "v5__add_business_accountant_reference.js",
-            "atDate": ISODate()
-        });
 }

--- a/srv/db/v6__rename_invoice_vat_rates.js
+++ b/srv/db/v6__rename_invoice_vat_rates.js
@@ -1,23 +1,11 @@
-var script = db.getCollection('scripts').findOne({_id: 'v6__rename_invoice_vat_rates.js'});
+db.getCollection('invoices').update({}, {$rename: {"vats": "vatRates"}}, {multi: true});
 
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-    db.getCollection('invoices').update({}, {$rename: {"vats": "vatRates"}}, {multi: true});
-
-    db.getCollection('invoices').find({}).forEach(function (invoice) {
-        invoice.vatRates.forEach(function (vatRate) {
-            vatRate.label = vatRate.vat;
-            vatRate.rate = vatRate.amount;
-            delete vatRate.vat;
-            delete vatRate.amount;
-            db.getCollection('invoices').save(invoice);
-        });
+db.getCollection('invoices').find({}).forEach(function (invoice) {
+    invoice.vatRates.forEach(function (vatRate) {
+        vatRate.label = vatRate.vat;
+        vatRate.rate = vatRate.amount;
+        delete vatRate.vat;
+        delete vatRate.amount;
+        db.getCollection('invoices').save(invoice);
     });
-
-    db.getCollection('scripts').save(
-        {
-            _id: "v6__rename_invoice_vat_rates.js",
-            "atDate": ISODate()
-        });
-}
+});

--- a/srv/db/v7__rename_line_vat_rate.js
+++ b/srv/db/v7__rename_line_vat_rate.js
@@ -1,33 +1,21 @@
-var script = db.getCollection('scripts').findOne({_id: 'v7__rename_line_vat_rate.js'});
-
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-    db.getCollection('invoices').find({}).forEach(function (invoice) {
-        invoice.lines.forEach(function (line) {
-            if (line.vat) {
-                line.vat.label = line.vat.vat;
-                line.vat.rate = line.vat.amount;
-                delete line.vat.vat;
-                delete line.vat.amount;
-                db.getCollection('invoices').save(invoice);
-            }
-        });
+db.getCollection('invoices').find({}).forEach(function (invoice) {
+    invoice.lines.forEach(function (line) {
+        if (line.vat) {
+            line.vat.label = line.vat.vat;
+            line.vat.rate = line.vat.amount;
+            delete line.vat.vat;
+            delete line.vat.amount;
+            db.getCollection('invoices').save(invoice);
+        }
     });
+});
 
-    db.getCollection('invoices').find({}).forEach(function (invoice) {
-        invoice.lines.forEach(function (line) {
-            if (line.vat) {
-                line.vatRate = line.vat;
-                delete line.vat;
-                db.getCollection('invoices').save(invoice);
-            }
-        });
+db.getCollection('invoices').find({}).forEach(function (invoice) {
+    invoice.lines.forEach(function (line) {
+        if (line.vat) {
+            line.vatRate = line.vat;
+            delete line.vat;
+            db.getCollection('invoices').save(invoice);
+        }
     });
-
-    db.getCollection('scripts').save(
-        {
-            _id: "v7__rename_line_vat_rate.js",
-            "atDate": ISODate()
-        });
-}
+});

--- a/srv/db/v8__rename_invoice_vat_amount.js
+++ b/srv/db/v8__rename_invoice_vat_amount.js
@@ -1,19 +1,7 @@
-var script = db.getCollection('scripts').findOne({_id: 'v8__rename_invoice_vat_amount.js'});
-
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-    db.getCollection('invoices').find({}).forEach(function (invoice) {
-        invoice.vatsAmount.forEach(function (vatAmount) {
-            vatAmount.label = vatAmount.vat;
-            delete vatAmount.vat;
-            db.getCollection('invoices').save(invoice);
-        });
+db.getCollection('invoices').find({}).forEach(function (invoice) {
+    invoice.vatsAmount.forEach(function (vatAmount) {
+        vatAmount.label = vatAmount.vat;
+        delete vatAmount.vat;
+        db.getCollection('invoices').save(invoice);
     });
-
-    db.getCollection('scripts').save(
-        {
-            _id: "v8__rename_invoice_vat_amount.js",
-            "atDate": ISODate()
-        });
-}
+});

--- a/srv/db/v9__synchronise_invoice_vat_rates_with_lines_rates.js
+++ b/srv/db/v9__synchronise_invoice_vat_rates_with_lines_rates.js
@@ -1,30 +1,17 @@
-var script = db.getCollection('scripts').findOne({_id: 'v9__synchronise_invoice_vat_rates_with_lines_rates.js'});
-
-if (script) {
-    print("This script was already launched at " + script.atDate);
-} else {
-
-
-    function extractLinesVatRates(lines) {
-        var vatRates = [];
-        lines.forEach(function (line) {
-            if (line.vatRate && line.vatRate.rate) {
-                vatRates.push(line.vatRate);
-            }
-        });
-        return vatRates;
-    }
-
-    db.getCollection('invoices').find({vatRates: {$size: 0}}).forEach(function (invoice) {
-        var vatRates = extractLinesVatRates(invoice.lines);
-        if (vatRates.length > 0) {
-            invoice.vatRates = vatRates;
-            db.getCollection('invoices').save(invoice);
+function extractLinesVatRates(lines) {
+    var vatRates = [];
+    lines.forEach(function (line) {
+        if (line.vatRate && line.vatRate.rate) {
+            vatRates.push(line.vatRate);
         }
     });
-    db.getCollection('scripts').save(
-        {
-            _id: "v9__synchronise_invoice_vat_rates_with_lines_rates.js",
-            "atDate": ISODate()
-        });
+    return vatRates;
 }
+
+db.getCollection('invoices').find({vatRates: {$size: 0}}).forEach(function (invoice) {
+    var vatRates = extractLinesVatRates(invoice.lines);
+    if (vatRates.length > 0) {
+        invoice.vatRates = vatRates;
+        db.getCollection('invoices').save(invoice);
+    }
+});

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -22,6 +22,13 @@
         <junit.version>5.6.1</junit.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>${project.war.overlay.groupId}</groupId>
@@ -188,6 +195,16 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.4sh.datamaintain</groupId>
+            <artifactId>datamaintain-core</artifactId>
+            <version>v1.0.0-rc8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.4sh.datamaintain</groupId>
+            <artifactId>datamaintain-driver-mongo</artifactId>
+            <version>v1.0.0-rc8</version>
+        </dependency>
     </dependencies>
 
 

--- a/srv/src/main/java/rxinvoice/ApplicationStart.java
+++ b/srv/src/main/java/rxinvoice/ApplicationStart.java
@@ -1,0 +1,18 @@
+package rxinvoice;
+
+import restx.factory.AutoStartable;
+import restx.factory.Component;
+
+@Component
+public class ApplicationStart implements AutoStartable {
+    private final DatamaintainAutoMigrate datamaintainAutoMigrate;
+
+    public ApplicationStart(DatamaintainAutoMigrate datamaintainAutoMigrate) {
+        this.datamaintainAutoMigrate = datamaintainAutoMigrate;
+    }
+
+    @Override
+    public void start() {
+        datamaintainAutoMigrate.start();
+    }
+}

--- a/srv/src/main/java/rxinvoice/DatamaintainAutoMigrate.java
+++ b/srv/src/main/java/rxinvoice/DatamaintainAutoMigrate.java
@@ -1,0 +1,33 @@
+package rxinvoice;
+
+import datamaintain.core.Datamaintain;
+import datamaintain.core.config.DatamaintainConfig;
+import datamaintain.core.db.driver.DatamaintainDriverConfig;
+import datamaintain.db.driver.mongo.MongoDriverConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import restx.factory.Component;
+
+import java.util.Properties;
+
+@Component
+public class DatamaintainAutoMigrate {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatamaintainAutoMigrate.class);
+    private final DatamaintainSettings datamaintainSettings;
+
+    public DatamaintainAutoMigrate(DatamaintainSettings datamaintainSettings) {
+        this.datamaintainSettings = datamaintainSettings;
+    }
+
+    public void start() {
+        final Properties properties = new Properties();
+        properties.put("scan.identifier.regex", datamaintainSettings.scanIdentifierRegex());
+        properties.put("db.mongo.uri", datamaintainSettings.dbMongoUri());
+        properties.put("scan.path", datamaintainSettings.scanPath());
+
+        final DatamaintainDriverConfig datamaintainDriverConfig = MongoDriverConfig.buildConfig(properties);
+        final DatamaintainConfig datamaintainConfig = DatamaintainConfig.buildConfig(datamaintainDriverConfig, properties);
+        new Datamaintain(datamaintainConfig).updateDatabase();
+    }
+}

--- a/srv/src/main/java/rxinvoice/DatamaintainSettings.java
+++ b/srv/src/main/java/rxinvoice/DatamaintainSettings.java
@@ -1,0 +1,16 @@
+package rxinvoice;
+
+import restx.config.Settings;
+import restx.config.SettingsKey;
+
+@Settings
+public interface DatamaintainSettings {
+    @SettingsKey(key = "scan.path")
+    String scanPath();
+
+    @SettingsKey(key = "scan.identifier.regex")
+    String scanIdentifierRegex();
+
+    @SettingsKey(key = "db.mongo.uri")
+    String dbMongoUri();
+}

--- a/srv/src/main/resources/settings/settings.dev.properties
+++ b/srv/src/main/resources/settings/settings.dev.properties
@@ -1,2 +1,4 @@
 serverAddress=http://localhost:4200/
 mongo.db=rxinvoice
+scan.path=db
+db.mongo.uri=mongodb://localhost:27017/rxinvoice

--- a/srv/src/main/resources/settings/settings.properties
+++ b/srv/src/main/resources/settings/settings.properties
@@ -1,1 +1,2 @@
 mongo.db=rxinvoice
+scan.identifier.regex=(.*?)__.*


### PR DESCRIPTION
I did all the setup for the server to use Datamaintain.

Your scripts will be played in the order defined by their identifiers. All your scripts start with the following name convention: "vX__my-script-name.js" so I configured Datamaintain to identifiy "vX" as the identifier. 

You now have two choices:
- let Datamaintain execute all the scripts on the different environments where invoice is, which may lead to errors if they are not written to be executed twice
- use the CLI on the different environments where invoice is deployed to mark the scripts as executed. To do that, [download the CLI ](https://github.com/4sh/datamaintain/releases/download/v1.0.0-rc8/cli.tar)from the Datamaintain repository and run it using the following command:
```./datamaintain-cli --db-type mongo --mongo-uri $MONGO_URI update-db --path $PATH --identifier-regex $REGEX --execution-mode FORCE_MARK_AS_EXECUTED```
$MONGO_URI should be the uri to your database, it should look like that: ```mongodb://localhost:27017/rxinvoice```
$PATH is the absolute path to the folder where your scripts are stored
$REGEX is the regex used to find the identifier in your script names. You may use the one I put in the settings, ```(.*?)__.*```.