### PR TITLE
SIMINVOICE-27: Show negatif grossAmount

### DIFF
--- a/ui/src/app/modules/invoice/components/a-invoice-line/a-invoice-line.component.html
+++ b/ui/src/app/modules/invoice/components/a-invoice-line/a-invoice-line.component.html
@@ -30,7 +30,7 @@
                    placeholder="{{'invoice.line.unit.cost'|translate}}">
         </div>
         <div class="cell phone-3 grid-x align-right">
-            <span>{{line?.grossAmount > 0 ? (line?.grossAmount | invoiceCurrency) : ''}}</span>
+            <span>{{line?.grossAmount | invoiceCurrency}}</span>
         </div>
         <div class="cell phone-4 grid-x align-right">
             <span *ngIf="!editable && invoice.withVAT">{{line?.vatRate?.rate | number: '1.2'}} {{line?.vatRate?.rate ? ' %' : ''}}</span>


### PR DESCRIPTION
Lorsque l’on indique dans le corps d’une facture une ligne en moins (ex : remise exceptionnelle), le montant HT n'apparaît pas
Resolve: https://issues.4sh.fr/browse/SIMINVOICE-27