### PR TITLE
SIMINVOICE-29: feat: remove status filter

### DIFF
--- a/ui/src/app/modules/shared/components/atoms/selects/a-invoice-status-select/a-invoice-status-select.component.html
+++ b/ui/src/app/modules/shared/components/atoms/selects/a-invoice-status-select/a-invoice-status-select.component.html
@@ -1,7 +1,7 @@
 <ng-select
         [items]="items"
         [bindLabel]="'label'"
-        [clearable]="false"
+        [clearable]="true"
         [searchable]="false"
         [ngModel]="selectedItem"
         [ngClass]="invoiceStatus"

--- a/ui/src/app/modules/shared/components/atoms/selects/a-invoice-status-select/a-invoice-status-select.component.ts
+++ b/ui/src/app/modules/shared/components/atoms/selects/a-invoice-status-select/a-invoice-status-select.component.ts
@@ -73,6 +73,10 @@ export class AInvoiceStatusSelectComponent implements OnInit, ControlValueAccess
     }
 
     onChange(enumOption: EnumOption) {
+        if (!enumOption) {
+            this.onNgChange(null);
+            return;
+        }
         this.invoiceStatus = enumOption.value as InvoiceStatusType;
         this.selectedItem = enumOption;
         this.onNgChange(this.invoiceStatus);


### PR DESCRIPTION
Lorsque l’on active une recherche par statuts, il est impossible par la suite de remettre sans filtre de “statuts” = remettre à zéro le critère (on doit absolument choisir un statut)


Resolve: https://issues.4sh.fr/browse/SIMINVOICE-29